### PR TITLE
Use lite BlazePose model and reset detector on camera changes

### DIFF
--- a/docs/tfjs.js
+++ b/docs/tfjs.js
@@ -13,19 +13,20 @@ const cameraWrapper=document.getElementById('cameraWrapper');
 
 let detector=null; let running=false; let lastTs=performance.now(); let frames=0;
 let currentStream=null; const isMobile=/Android|iPhone|iPad|iPod/i.test(navigator.userAgent); let usingFrontCamera=true;
+const modelType=isMobile?'lite':'heavy';
 if(!isMobile){ flipBtn.style.display='none'; cameraWrapper.style.display=''; populateCameras(); usingFrontCamera=false; }
 else{ cameraWrapper.style.display='none'; }
 confRange.addEventListener('input',()=>confVal.textContent=Number(confRange.value).toFixed(2));
-startBtn.addEventListener('click',async()=>{ await setupBackend(); await createDetector(); await startCamera(); running=true; requestAnimationFrame(loop); });
-flipBtn.addEventListener('click',async()=>{ usingFrontCamera=!usingFrontCamera; if(running){ await startCamera(); await createDetector(); } else { applyMirror(); } });
-cameraSel.addEventListener('change',async()=>{ if(running) await startCamera(); });
+startBtn.addEventListener('click',async()=>{ await setupBackend(); await startCamera(); await createDetector(); running=true; requestAnimationFrame(loop); });
+flipBtn.addEventListener('click',async()=>{ usingFrontCamera=!usingFrontCamera; if(running){ running=false; if(detector) detector.dispose(); detector=null; await startCamera(); await createDetector(); running=true; requestAnimationFrame(loop); } else { applyMirror(); } });
+cameraSel.addEventListener('change',async()=>{ if(running){ running=false; if(detector) detector.dispose(); detector=null; await startCamera(); await createDetector(); running=true; requestAnimationFrame(loop); } });
 
 async function setupBackend(){ await tf.setBackend('webgl'); await tf.ready(); }
 async function createDetector(){
   const pd=window.poseDetection; if(!pd){ alert('pose-detection failed to load.'); throw new Error('poseDetection not available'); }
   const m=pd.SupportedModels.BlazePose;
-  const type='heavy';
-  chipModel.innerHTML='Model<strong>Heavy</strong>';
+  const type=modelType;
+  chipModel.innerHTML='Model<strong>'+(type==='lite'?'Lite':type==='full'?'Full':'Heavy')+'</strong>';
   // Try MediaPipe runtime first; if it fails, fallback to TFJS runtime
   try{
     detector=await pd.createDetector(m,{ runtime:'mediapipe', solutionPath:'https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404', modelType:type, enableSmoothing:true, selfieMode:usingFrontCamera, minPoseDetectionConfidence:0.5, minPosePresenceConfidence:0.5, minTrackingConfidence:0.5 });
@@ -42,9 +43,9 @@ async function populateCameras(){
 }
 async function startCamera(){
   if(currentStream){ currentStream.getTracks().forEach(t=>t.stop()); }
-  const constraints={video:{width:640,height:480},audio:false};
-  if(isMobile){ constraints.video.facingMode=usingFrontCamera?'user':'environment'; }
-  else if(cameraSel.value){ constraints.video.deviceId={exact:cameraSel.value}; }
+  const constraints={video:{},audio:false};
+  if(isMobile){ constraints.video.facingMode=usingFrontCamera?'user':'environment'; constraints.video.width={ideal:320}; constraints.video.height={ideal:240}; }
+  else{ constraints.video.width=640; constraints.video.height=480; if(cameraSel.value){ constraints.video.deviceId={exact:cameraSel.value}; } }
   const stream=await navigator.mediaDevices.getUserMedia(constraints);
   currentStream=stream;
   const facing=stream.getVideoTracks()[0].getSettings().facingMode;


### PR DESCRIPTION
## Summary
- switch to BlazePose `lite` model and lower mobile video resolution for higher FPS
- reset camera stream and detector when flipping or selecting a camera so motion capture continues working

## Testing
- `node --check docs/tfjs.js`
- `python -m py_compile server.py pose_desktop.py`


------
https://chatgpt.com/codex/tasks/task_e_689db4d496b48326877f1626e166be67