### PR TITLE
Refactor pose detection to web worker with filtering and coaching logic

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
         <div class="chips">
           <div class="chip">Backend<strong>WebGL</strong></div>
           <div class="chip">Resolution<strong>Auto</strong></div>
-          <div class="chip" id="chipModel">Model<strong>Lite</strong></div>
+          <div class="chip" id="chipModel">Model<strong>Heavy</strong></div>
         </div>
         <div class="card grid">
           <div id="fps"><strong>FPS:</strong> –</div>

--- a/docs/pose_landmarker.js
+++ b/docs/pose_landmarker.js
@@ -1,8 +1,3 @@
-import {
-  PoseLandmarker,
-  FilesetResolver,
-} from "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.2";
-
 const video = document.getElementById("video");
 const canvas = document.getElementById("overlay");
 const ctx = canvas.getContext("2d");
@@ -17,14 +12,48 @@ const flipBtn = document.getElementById("flipBtn");
 const cameraSel = document.getElementById("cameraSelect");
 const cameraWrapper = document.getElementById("cameraWrapper");
 
-let landmarker = null;
+const DEFAULT_OPTIONS = {
+  runningMode: "VIDEO",
+  numPoses: 1,
+  minPoseDetectionConfidence: 0.60,
+  minPosePresenceConfidence: 0.75,
+  minTrackingConfidence: 0.70,
+  outputSegmentationMasks: false,
+};
+
+const PROFILES = {
+  lowLight: {
+    minPoseDetectionConfidence: 0.55,
+    minPosePresenceConfidence: 0.70,
+    minTrackingConfidence: 0.60,
+  },
+  repMoment: { minPosePresenceConfidence: 0.80 },
+  budget: {
+    minPoseDetectionConfidence: 0.55,
+    minPosePresenceConfidence: 0.70,
+    minTrackingConfidence: 0.65,
+  },
+};
+
+let currentOptions = { ...DEFAULT_OPTIONS };
 let running = false;
-let lastTs = performance.now();
-let frames = 0;
 let currentStream = null;
 const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 let usingFrontCamera = true;
+let worker = null;
+let usingLiteModel = false;
+let lastSent = 0;
+let detectionInterval = 1000 / 60;
+let frames = 0;
+let lastFpsTs = performance.now();
 const landmarkHistory = [];
+const lastGoodLandmarks = {};
+const smoothedLandmarks = {};
+let lastFrameTs = performance.now();
+let lastCorrectionTs = 0;
+const ruleFrames = { torso: 0, leftKnee: 0, rightKnee: 0 };
+let trackingLowSince = null;
+
 const LANDMARK_NAMES = [
   "nose",
   "left_eye_inner",
@@ -99,6 +128,7 @@ const FACE_LANDMARKS = new Set([
   "mouth_left",
   "mouth_right",
 ]);
+
 if (!isMobile) {
   flipBtn.style.display = "none";
   cameraWrapper.style.display = "";
@@ -107,60 +137,103 @@ if (!isMobile) {
 } else {
   cameraWrapper.style.display = "none";
 }
+
 confRange.addEventListener("input", () => {
   confidenceThreshold = Number(confRange.value);
   confVal.textContent = confidenceThreshold.toFixed(2);
 });
+
 startBtn.addEventListener("click", async () => {
   await startCamera();
-  await createLandmarker();
+  await createWorker("heavy");
   running = true;
   requestAnimationFrame(loop);
 });
+
 flipBtn.addEventListener("click", async () => {
   usingFrontCamera = !usingFrontCamera;
   if (running) {
     running = false;
-    if (landmarker) landmarker.close();
-    landmarker = null;
+    worker.postMessage({ type: "close" });
     await startCamera();
-    await createLandmarker();
+    await createWorker(usingLiteModel ? "lite" : "heavy");
     running = true;
     requestAnimationFrame(loop);
   } else {
     applyTransforms();
   }
 });
+
 cameraSel.addEventListener("change", async () => {
   if (running) {
     running = false;
-    if (landmarker) landmarker.close();
-    landmarker = null;
+    worker.postMessage({ type: "close" });
     await startCamera();
-    await createLandmarker();
+    await createWorker(usingLiteModel ? "lite" : "heavy");
     running = true;
     requestAnimationFrame(loop);
   }
 });
+
 window.addEventListener("orientationchange", applyTransforms);
 
-async function createLandmarker() {
-  const vision = await FilesetResolver.forVisionTasks(
-    "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.2/wasm",
-  );
-  const modelUrl =
-    "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_heavy/float16/1/pose_landmarker_heavy.task";
-  landmarker = await PoseLandmarker.createFromOptions(vision, {
-    baseOptions: { modelAssetPath: modelUrl, delegate: "GPU" },
-    runningMode: "LIVE_STREAM",
-    numPoses: 1,
-    minPoseDetectionConfidence: 0.3,
-    minPosePresenceConfidence: 0.3,
-    minTrackingConfidence: 0.3,
-    outputSegmentationMasks: true,
-  });
-  chipModel.innerHTML = "Model<strong>Heavy</strong>";
+async function createWorker(model) {
+  if (worker) worker.terminate();
+  worker = new Worker("./pose_worker.js", { type: "module" });
+  worker.onmessage = handleWorkerMessage;
+  worker.postMessage({ type: "init", options: currentOptions, model });
+  chipModel.innerHTML = `Model<strong>${model === "lite" ? "Lite" : "Heavy"}</strong>`;
+  usingLiteModel = model === "lite";
 }
+
+function handleWorkerMessage(e) {
+  if (e.data.type !== "result") return;
+  const res = e.data.result;
+  const latency = e.data.latency;
+  const keypoints = resultsToKeypoints(res);
+  if (keypoints) {
+    const sm = smoothKeypoints(keypoints);
+    drawKeypointsAndSkeleton(sm);
+    setTips(sm);
+    updatePoseScore(sm);
+    logLandmarks(sm);
+    checkTracking(sm);
+  }
+  updateFps();
+  adaptFrameRate(latency);
+}
+
+function adaptFrameRate(latency) {
+  detectionInterval = latency > 80 ? 1000 / 30 : 1000 / 60;
+}
+
+function checkTracking(kp) {
+  const valid = kp.filter((p) => p);
+  if (!valid.length) return;
+  const avg = valid.reduce((a, p) => a + (p.score || 0), 0) / valid.length;
+  const now = performance.now();
+  if (avg < 0.5) {
+    if (!trackingLowSince) trackingLowSince = now;
+    if (now - trackingLowSince > 500 && !usingLiteModel) {
+      createWorker("lite");
+      trackingLowSince = null;
+    }
+  } else {
+    trackingLowSince = null;
+  }
+}
+
+async function loop() {
+  if (!running) return;
+  const now = performance.now();
+  if (now - lastSent >= detectionInterval) {
+    const bitmap = await createImageBitmap(video);
+    worker.postMessage({ type: "frame", image: bitmap, ts: now }, [bitmap]);
+    lastSent = now;
+  }
+  requestAnimationFrame(loop);
+}
+
 async function populateCameras() {
   const devices = await navigator.mediaDevices.enumerateDevices();
   const vids = devices.filter((d) => d.kind === "videoinput");
@@ -172,6 +245,7 @@ async function populateCameras() {
     cameraSel.appendChild(o);
   });
 }
+
 async function startCamera() {
   if (currentStream) {
     currentStream.getTracks().forEach((t) => t.stop());
@@ -192,7 +266,6 @@ async function startCamera() {
   currentStream = stream;
   const facing = stream.getVideoTracks()[0].getSettings().facingMode;
   usingFrontCamera = !facing || facing === "user" || facing === "front";
-  // Wait for metadata before accessing video dimensions
   const ready = new Promise((r) => {
     if (video.readyState >= 1) r();
     else video.addEventListener("loadedmetadata", r, { once: true });
@@ -204,6 +277,7 @@ async function startCamera() {
   canvas.height = video.videoHeight;
   applyTransforms();
 }
+
 function applyTransforms() {
   const transforms = [];
   if (usingFrontCamera) transforms.push("scaleX(-1)");
@@ -212,39 +286,53 @@ function applyTransforms() {
   video.style.transform = t;
   canvas.style.transform = t;
 }
-function getKeypointConfidence(p) {
-  const visibility = p.visibility ?? 0;
-  const presence = p.presence ?? 0;
-  return Math.max(visibility, presence);
-}
+
+const VIS_THRESHOLD = 0.6;
+const PRES_THRESHOLD = 0.6;
+const HOLD_MS = 250;
+
 function resultsToKeypoints(res) {
   if (!res.landmarks || !res.landmarks.length) return null;
   const lm = res.landmarks[0];
+  const now = performance.now();
   return lm.map((p, i) => {
-    // Use the best visibility or presence score from the model.
-    return {
-      x: p.x * canvas.width,
-      y: p.y * canvas.height,
-      score: getKeypointConfidence(p),
-      name: LANDMARK_NAMES[i],
-    };
+    const name = LANDMARK_NAMES[i];
+    const vis = p.visibility ?? 0;
+    const pres = p.presence ?? 0;
+    if (vis >= VIS_THRESHOLD && pres >= PRES_THRESHOLD) {
+      const kp = {
+        x: p.x * canvas.width,
+        y: p.y * canvas.height,
+        score: Math.max(vis, pres),
+        name,
+      };
+      lastGoodLandmarks[name] = { ...kp, ts: now };
+      return kp;
+    }
+    const last = lastGoodLandmarks[name];
+    if (last && now - last.ts <= HOLD_MS) return last;
+    return null;
   });
 }
 
-function handleResult(res) {
-  const keypoints = resultsToKeypoints(res);
-  if (res.segmentationMasks) {
-    for (const m of res.segmentationMasks) {
-      if (m.close) m.close();
+function smoothKeypoints(kp) {
+  const now = performance.now();
+  const dt = (now - lastFrameTs) / 1000;
+  lastFrameTs = now;
+  const cutoff = 3; // tuned for 30-60 FPS
+  const alpha = 1 - Math.exp(-2 * Math.PI * cutoff * dt);
+  return kp.map((p) => {
+    if (!p) return null;
+    const prev = smoothedLandmarks[p.name];
+    if (prev) {
+      p.x = prev.x + alpha * (p.x - prev.x);
+      p.y = prev.y + alpha * (p.y - prev.y);
     }
-  }
-  if (keypoints) {
-    drawKeypointsAndSkeleton(keypoints);
-    setTips(keypoints);
-    updatePoseScore(keypoints);
-    logLandmarks(keypoints);
-  }
+    smoothedLandmarks[p.name] = { x: p.x, y: p.y, score: p.score };
+    return p;
+  });
 }
+
 function drawKeypointsAndSkeleton(keypoints) {
   const w = canvas.width;
   const h = canvas.height;
@@ -268,24 +356,16 @@ function drawKeypointsAndSkeleton(keypoints) {
     const pa = byName[a];
     const pb = byName[b];
     if (!pa || !pb) continue;
-    if (
-      (pa.score ?? 0) < confidenceThreshold ||
-      (pb.score ?? 0) < confidenceThreshold
-    )
-      continue;
+    if ((pa.score ?? 0) < confidenceThreshold || (pb.score ?? 0) < confidenceThreshold) continue;
     ctx.beginPath();
     ctx.moveTo(pa.x, pa.y);
     ctx.lineTo(pb.x, pb.y);
     ctx.stroke();
   }
 }
+
 function setTips(keypoints) {
-  tipsList.innerHTML = "";
-  const add = (t) => {
-    const li = document.createElement("li");
-    li.textContent = t;
-    tipsList.appendChild(li);
-  };
+  const now = performance.now();
   const byName = {};
   for (const p of keypoints) {
     if (p && p.name) byName[p.name] = p;
@@ -298,77 +378,80 @@ function setTips(keypoints) {
   const RH = "right_hip";
   const LK = "left_knee";
   const RK = "right_knee";
+  const tips = [];
+  let torsoBad = false;
   if (s(LS) && s(RS) && s(LH) && s(RH) && (s(LK) || s(RK))) {
-    const ms = {
-      x: (get(LS).x + get(RS).x) / 2,
-      y: (get(LS).y + get(RS).y) / 2,
-    };
-    const mh = {
-      x: (get(LH).x + get(RH).x) / 2,
-      y: (get(LH).y + get(RH).y) / 2,
-    };
+    const ms = { x: (get(LS).x + get(RS).x) / 2, y: (get(LS).y + get(RS).y) / 2 };
+    const mh = { x: (get(LH).x + get(RH).x) / 2, y: (get(LH).y + get(RH).y) / 2 };
     const knee = s(LK) ? get(LK) : get(RK);
     const torso = angleDeg(ms, mh, knee);
-    if (torso != null && torso < 150) {
-      add("Keep chest up, reduce torso lean.");
-    }
+    if (torso != null && torso < 150) torsoBad = true;
   }
-  if (s(LK) && s(LH) && Math.abs(get(LK).x - get(LH).x) > canvas.width * 0.2) {
-    add("Left knee drifting; align over foot.");
+  ruleFrames.torso = torsoBad ? ruleFrames.torso + 1 : 0;
+  if (ruleFrames.torso >= 3 && now - lastCorrectionTs > 1500) {
+    tips.push("Keep chest up, reduce torso lean.");
+    lastCorrectionTs = now;
+    ruleFrames.torso = 0;
   }
-  if (s(RK) && s(RH) && Math.abs(get(RK).x - get(RH).x) > canvas.width * 0.2) {
-    add("Right knee drifting; align over foot.");
+  let leftKneeBad = false;
+  if (s(LK) && s(LH) && Math.abs(get(LK).x - get(LH).x) > canvas.width * 0.2) leftKneeBad = true;
+  ruleFrames.leftKnee = leftKneeBad ? ruleFrames.leftKnee + 1 : 0;
+  if (ruleFrames.leftKnee >= 3 && now - lastCorrectionTs > 1500) {
+    tips.push("Left knee drifting; align over foot.");
+    lastCorrectionTs = now;
+    ruleFrames.leftKnee = 0;
   }
-  if (!tipsList.children.length) add("Nice form!");
+  let rightKneeBad = false;
+  if (s(RK) && s(RH) && Math.abs(get(RK).x - get(RH).x) > canvas.width * 0.2) rightKneeBad = true;
+  ruleFrames.rightKnee = rightKneeBad ? ruleFrames.rightKnee + 1 : 0;
+  if (ruleFrames.rightKnee >= 3 && now - lastCorrectionTs > 1500) {
+    tips.push("Right knee drifting; align over foot.");
+    lastCorrectionTs = now;
+    ruleFrames.rightKnee = 0;
+  }
+  tipsList.innerHTML = "";
+  if (!tips.length) tips.push("Nice form!");
+  for (const t of tips) {
+    const li = document.createElement("li");
+    li.textContent = t;
+    tipsList.appendChild(li);
+  }
 }
+
 function angleDeg(a, b, c) {
-  const v1 = [a.x - b.x, a.y - b.y],
-    v2 = [c.x - b.x, c.y - b.y];
+  const v1 = [a.x - b.x, a.y - b.y];
+  const v2 = [c.x - b.x, c.y - b.y];
   const dot = v1[0] * v2[0] + v1[1] * v2[1];
-  const m1 = Math.hypot(v1[0], v1[1]),
-    m2 = Math.hypot(v2[0], v2[1]);
+  const m1 = Math.hypot(v1[0], v1[1]);
+  const m2 = Math.hypot(v2[0], v2[1]);
   if (m1 === 0 || m2 === 0) return null;
   const cos = Math.min(1, Math.max(-1, dot / (m1 * m2)));
   return (Math.acos(cos) * 180) / Math.PI;
 }
-async function loop() {
-  if (!running) return;
-  try {
-    // Process the current video frame and draw results immediately
-    const res = landmarker.detectForVideo(video, performance.now());
-    if (res) handleResult(res);
-  } catch (e) {
-    console.warn("detectForVideo failed; resetting landmarker", e);
-    try {
-      await createLandmarker();
-    } catch (_) {}
-  }
-  updateFps();
-  requestAnimationFrame(loop);
-}
+
 function updateFps() {
   frames++;
   const now = performance.now();
-  if (now - lastTs >= 1000) {
-    const fps = frames / ((now - lastTs) / 1000);
+  if (now - lastFpsTs >= 1000) {
+    const fps = (frames * 1000) / (now - lastFpsTs);
     fpsEl.innerHTML = `<strong>FPS:</strong> ${fps.toFixed(1)}`;
     frames = 0;
-    lastTs = now;
+    lastFpsTs = now;
   }
 }
+
 function updatePoseScore(kp) {
   const el = document.getElementById("poseScore");
-  const mean =
-    kp.map((p) => p.score ?? 0).reduce((a, b) => a + b, 0) / kp.length;
+  const valid = kp.filter((p) => p);
+  const mean = valid.reduce((a, b) => a + (b.score || 0), 0) / valid.length;
   el.innerHTML = `<strong>Pose score:</strong> ${mean.toFixed(2)}`;
 }
+
 function logLandmarks(kp) {
-  const snapshot = kp.map((p) => ({
-    x: p.x,
-    y: p.y,
-    score: p.score,
-    name: p.name,
-  }));
+  const snapshot = kp
+    .filter((p) => p)
+    .map((p) => ({ x: p.x, y: p.y, score: p.score, name: p.name }));
   landmarkHistory.push({ ts: performance.now(), keypoints: snapshot });
   if (landmarkHistory.length > 1000) landmarkHistory.shift();
 }
+

--- a/docs/pose_worker.js
+++ b/docs/pose_worker.js
@@ -1,0 +1,36 @@
+import { PoseLandmarker, FilesetResolver } from "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.2";
+
+let landmarker = null;
+let running = false;
+
+self.onmessage = async (e) => {
+  const { type } = e.data;
+  if (type === "init") {
+    if (landmarker) landmarker.close();
+    const opts = e.data.options || {};
+    const model = e.data.model === "lite" ?
+      "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task" :
+      "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_heavy/float16/1/pose_landmarker_heavy.task";
+    const vision = await FilesetResolver.forVisionTasks(
+      "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.2/wasm",
+    );
+    landmarker = await PoseLandmarker.createFromOptions(vision, {
+      baseOptions: { modelAssetPath: model, delegate: "GPU" },
+      ...opts,
+    });
+    running = true;
+  } else if (type === "frame" && running && landmarker) {
+    const bitmap = e.data.image;
+    const ts = e.data.ts;
+    const t0 = performance.now();
+    const res = landmarker.detectForVideo(bitmap, ts);
+    const latency = performance.now() - t0;
+    bitmap.close();
+    self.postMessage({ type: "result", result: { landmarks: res.landmarks }, latency });
+  } else if (type === "close") {
+    running = false;
+    if (landmarker) landmarker.close();
+    landmarker = null;
+  }
+};
+


### PR DESCRIPTION
## Summary
- Run MediaPipe pose detection inside a Web Worker with configurable model options
- Add landmark gating, temporal smoothing, and rate‑limited coaching tips
- Adapt inference FPS and swap to Lite model on low tracking confidence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e03652cb08326b3f423cee2e83740